### PR TITLE
Notify base owners of base raid when grinding or hacking

### DIFF
--- a/@ExileServer/addons/exad_grinding/Functions/fn_grindProgress.sqf
+++ b/@ExileServer/addons/exad_grinding/Functions/fn_grindProgress.sqf
@@ -22,6 +22,14 @@ _object = objectFromNetId ([_this, 0, "",[""]] call BIS_fnc_param);
 
 if(isNull _object)exitWith{false};
 
+_territory = _object call ExileClient_util_world_getTerritoryAtPosition;
+_serverTime = time;
+if(_serverTime > ((_territory getVariable ["ExileXM8MobileNotifiedTime",-1800]) + 1800))then
+{
+	_territory call ExileServer_system_xm8_sendBaseRaid;
+	_territory setVariable ["ExileXM8MobileNotifiedTime", _serverTime];
+};
+
 if((_object getVariable ["ExAd_Grinding_progress", 0]) >= ExAd_GRINDING_OBJECT_MAX)then{
 	_object setVariable ["ExileAccessCode", nil];
 	_object setVariable ["ExileIsLocked", nil, true];

--- a/@ExileServer/addons/exad_hacking/Functions/fn_startHack.sqf
+++ b/@ExileServer/addons/exad_hacking/Functions/fn_startHack.sqf
@@ -44,6 +44,14 @@ if(isNil "ExAd_HACKS_IN_PROGRESS")then{
 
 ["Hacking", format["Hack started: Player - %1(%2)|Territory - %3|Hacks in motion - %4",name _player, getPlayerUID _player, _flag getVariable ["ExileTerritoryName", "Unknown"], ExAd_HACKS_IN_PROGRESS]] call ExAdServer_fnc_log;
 
+_territory = _flag call ExileClient_util_world_getTerritoryAtPosition;
+_serverTime = time;
+if(_serverTime > ((_territory getVariable ["ExileXM8MobileNotifiedTime",-1800]) + 1800))then
+{
+	_territory call ExileServer_system_xm8_sendBaseRaid;
+	_territory setVariable ["ExileXM8MobileNotifiedTime", _serverTime];
+};
+
 _pos = _player modelToWorld [0, +0.5, 0];
 _pos set [2,((getPosATL _player) select 2)];
 


### PR DESCRIPTION
Small little tweak to replicate behaviour of when someone is blasting walls, for hacking and grinding to notify players via the XM8 App/Bot when their base is under attack