### PR TITLE
Fix for cause of various errors. - Thx to Cloud

### DIFF
--- a/@ExileServer/addons/exad_hacking/Functions/fn_startHack.sqf
+++ b/@ExileServer/addons/exad_hacking/Functions/fn_startHack.sqf
@@ -24,6 +24,8 @@ if(isNull _object || isNull _player)exitWith{false};
 
 _flag = ((getPos _object) nearObjects ["Exile_Construction_Flag_Static", 150]) select 0;
 
+if(_flag isEqualTo objNull)exitWith{false};
+
 if(ExAd_HACKING_PLAYER_ONLINE && !([_flag] call ExAdServer_fnc_territoryPlayerPresent))exitWith{
 	[STR_ExAd_HACKING_NOTI_NO_PLAYER_PRESENT ,0,0.6,2,0] remoteExec ["BIS_fnc_dynamicText",owner _player];
 };


### PR DESCRIPTION
21:14:46 Error in expression <;
_access = [0, "None"];
try
{
_owner = _flag getVariable ["ExileOwnerUID", ""];>
21:14:46   Error position: <_flag getVariable ["ExileOwnerUID", ""];>
21:14:46   Error Undefined variable in expression: _flag
21:14:46 File exile_client\code\ExileClient_util_territory_getAccessLevel.sqf, line 18
21:14:46 Error in expression <["_flag","_res"]; _res = false;{  if( (([_flag, getPlayerUID _x ] call ExileClien>
21:14:46   Error position: <_flag, getPlayerUID _x ] call ExileClien>
21:14:46   Error Undefined variable in expression: _flag
21:14:46 File exad_core\Functions\Utils\fn_territoryPlayerPresent.sqf [ExAdServer_fnc_territoryPlayerPresent], line 1
21:14:46 Error in expression <0;
 
if(ExAd_HACKING_PLAYER_ONLINE && !([_flag] call ExAdServer_fnc_territoryPlay>
21:14:46   Error position: <_flag] call ExAdServer_fnc_territoryPlay>
21:14:46   Error Undefined variable in expression: _flag
21:14:46 File exad_hacking\Functions\fn_startHack.sqf [ExAdServer_fnc_startHack], line 27
21:14:46 Error in expression <;
_access = [0, "None"];
try
{
_owner = _flag getVariable ["ExileOwnerUID", ""];>
21:14:46   Error position: <_flag getVariable ["ExileOwnerUID", ""];>
21:14:46   Error Undefined variable in expression: _flag
21:14:46 File exile_client\code\ExileClient_util_territory_getAccessLevel.sqf, line 18

Fixes those and many other errors related.